### PR TITLE
Remove white-spaces, tabs and new-lines from screenshot urls before fetching in sync

### DIFF
--- a/sync.php
+++ b/sync.php
@@ -44,7 +44,7 @@ foreach($supportedVersions as $version) {
 	$apps = json_decode($json, true);
 	foreach($apps as $app) {
 		foreach($app['screenshots'] as $screenshot) {
-			$url = preg_replace('/\s+/', '', $screenshot['url']);
+			$url = trim($screenshot['url']);
 			if(!file_exists(__DIR__ . '/cache/' . base64_encode($url))) {
 				if (substr($url, 0, 8) === 'https://') {
 					$data = file_get_contents($url);

--- a/sync.php
+++ b/sync.php
@@ -44,7 +44,7 @@ foreach($supportedVersions as $version) {
 	$apps = json_decode($json, true);
 	foreach($apps as $app) {
 		foreach($app['screenshots'] as $screenshot) {
-			$url = $screenshot['url'];
+			$url = preg_replace('/\s+/', '', $screenshot['url']);
 			if(!file_exists(__DIR__ . '/cache/' . base64_encode($url))) {
 				if (substr($url, 0, 8) === 'https://') {
 					$data = file_get_contents($url);

--- a/sync.php
+++ b/sync.php
@@ -44,10 +44,11 @@ foreach($supportedVersions as $version) {
 	$apps = json_decode($json, true);
 	foreach($apps as $app) {
 		foreach($app['screenshots'] as $screenshot) {
-			$url = trim($screenshot['url']);
+			$url = $screenshot['url'];
 			if(!file_exists(__DIR__ . '/cache/' . base64_encode($url))) {
-				if (substr($url, 0, 8) === 'https://') {
-					$data = file_get_contents($url);
+				$trimmedUrl = trim($url);
+				if (substr($trimmedUrl, 0, 8) === 'https://') {
+					$data = file_get_contents($trimmedUrl);
 					file_put_contents(__DIR__ . '/cache/' . base64_encode($url), $data);
 					echo(
 						sprintf(


### PR DESCRIPTION
Apps sometimes contain leading and trailing white-spaces, tabs and new-lines in screenshot urls like:
```
<screenshot small-thumbnail="https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/viewer1-small.png">
    https://raw.githubusercontent.com/ayselafsar/dicomviewer/master/screenshots/viewer1.png
</screenshot>
```
I think they should be removed before fetching screenshots in synchronization. Otherwise, screenshots for such apps are not displayed in Nextcloud:
<kbd><img width="347" alt="screen shot 2018-03-28 at 20 51 28" src="https://user-images.githubusercontent.com/8215016/38063967-f0cf1828-32c9-11e8-9cb7-22ebfde65ac2.png"></kbd>