### PR TITLE
 fix(sync): replace non-image or very large screenshots with warning images

### DIFF
--- a/index.php
+++ b/index.php
@@ -17,7 +17,7 @@ $cacheItem = substr($_SERVER['REQUEST_URI'], 1);
 $realPath = realpath(__DIR__ . '/cache/' . $cacheItem);
 $cacheDir = realpath(__DIR__ . '/cache/');
 
-if ($realPath === false || strpos($realPath, $cacheDir . DIRECTORY_SEPARATOR) !== 0) {
+if ($realPath === false || !str_starts_with($realPath, $cacheDir . DIRECTORY_SEPARATOR)) {
 	die('File not found');
 }
 

--- a/sync.php
+++ b/sync.php
@@ -25,7 +25,7 @@ function handleApps(array $apps): void {
 			$url = $screenshot['url'];
 			if (!file_exists(__DIR__ . '/cache/' . base64_encode($url))) {
 				$trimmedUrl = trim($url);
-				if (substr($trimmedUrl, 0, 8) === 'https://') {
+				if (str_starts_with($trimmedUrl, 'https://')) {
 					$data = file_get_contents($trimmedUrl);
 					file_put_contents(__DIR__ . '/cache/' . base64_encode($url), $data);
 					echo(

--- a/sync.php
+++ b/sync.php
@@ -12,6 +12,11 @@ if (php_sapi_name() !== 'cli') {
 }
 
 $allVersionsJson = file_get_contents('https://apps.nextcloud.com/api/v1/platforms.json');
+
+if ($allVersionsJson === false) {
+	die('Unable to read platforms.json');
+}
+
 $allVersions = json_decode($allVersionsJson, true);
 $supportedVersionObjects = array_filter($allVersions, fn (array $ver): bool => $ver['isSupported'] && str_ends_with($ver['version'], '.0.0'));
 $supportedVersions = array_map(fn (array $ver): string => $ver['version'], $supportedVersionObjects);
@@ -45,10 +50,20 @@ foreach($supportedVersions as $version) {
 		sprintf('https://apps.nextcloud.com/api/v1/platform/%s/apps.json', $version)
 	);
 
+	if ($json === false) {
+		echo(sprintf("Unable to read apps.json for version %s\n", $version));
+		continue;
+	}
+
 	$apps = json_decode($json, true);
     handleApps($apps);
 }
 
 $json = file_get_contents('https://apps.nextcloud.com/api/v1/appapi_apps.json');
+
+if ($json === false) {
+	die('Unable to read appapi_apps.json');
+}
+
 $apps = json_decode($json, true);
 handleApps($apps);


### PR DESCRIPTION
Along with some minor refactoring, this PR validates data downloaded from the screenshot URLs in every app's `info.xml`, ensuring that every screenshot actually consists of image data. We also now impose a file size limit on every screenshot. An auto-generated image replaces every screenshot that is either not recognized as an image (e.g. 404 Not Found) or too large in size.

Example images:
<img width="640" height="360" alt="test1" src="https://github.com/user-attachments/assets/f13be76e-a217-40c5-b4c5-83593c780297" />
<img width="640" height="360" alt="test2" src="https://github.com/user-attachments/assets/7eb438f3-fc2c-4ec7-bbd4-f37a22a9dff5" />